### PR TITLE
cross-compile to scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   test:
@@ -10,8 +13,8 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.8
-          - 2.12.15
+          - 3.8.4
+          - 2.13.18
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v4
     secrets: inherit

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,96 @@
+# Main goals:
+# - nicer commit diffs (trailing commas, no alignment for pattern matching, force new lines)
+# - better interop with default IntelliJ IDEA setup (matching import and modifiers sorting logic)
+# - better developer experience on laptop screens (like 16' MBPs) with IntelliJ IDEA (line wraps)
+
+version = 3.11.1
+
+runner.dialect = scala213source3
+
+# only format files tracked by git
+project.git = true
+
+maxColumn = 120
+trailingCommas = always
+
+preset = default
+# do not align to make nicer commit diffs
+align.preset = none
+
+indent {
+  # altering defnSite and extendSite to have this:
+  #   final class MyErr extends RuntimeException(
+  #     "super error message",
+  #   )
+  # instead of this:
+  #   final class MyErr extends RuntimeException(
+  #       "super error message",
+  #     )
+  defnSite = 2
+  extendSite = 0
+}
+
+spaces {
+  # makes string interpolation with curlies more visually distinct
+  inInterpolatedStringCurlyBraces = true
+}
+
+newlines {
+  # keep author new lines where possible
+  source = keep
+  # force new line after "(implicit" for multi-line arg lists
+  implicitParamListModifierForce = [after]
+  avoidForSimpleOverflow = [
+    tooLong, # if the line would be too long even after newline inserted, do nothing
+    slc, # do nothing if overflow caused by single line comment
+  ]
+}
+
+verticalMultiline {
+  atDefnSite = true
+  arityThreshold = 4 # more than 3 args in a list will be turned vertical
+  newlineAfterOpenParen = true # for nicer commit diffs
+}
+
+# for nicer commit diffs - forces new line before last parenthesis:
+#   class MyCls(
+#     arg1: String,
+#     arg2: String,
+#   ) extends MyTrait {
+#
+# without it:
+#   class MyCls(
+#     arg1: String,
+#     arg2: String) extends MyTrait {
+danglingParentheses.exclude = []
+
+docstrings {
+  # easier to view diffs in IDEA on 16' MBP screen if docs max line are shorter than code
+  wrapMaxColumn = 100
+  # next settings make it similar to the default IDEA javadoc formatting
+  style = Asterisk
+  oneline = unfold
+  blankFirstLine = unfold
+}
+
+rewrite.rules = [
+  Imports,
+  RedundantParens,
+  SortModifiers,
+  prefercurlyfors,
+]
+
+# put visibility modifier first
+rewrite.sortModifiers.preset = styleGuide
+
+# Import sorting as similar as possible to scalafix's "OrganizeImports.preset = INTELLIJ_2020_3".
+# Scalafix is not used as its commands mess up "all .." build aliases and it takes long time to run,
+# while its code semantic based features are not needed here.
+# I.e. detection of unused imports is done with Scala compiler options.
+rewrite.imports {
+  sort = ascii
+  groups = [
+    [".*"],
+    ["java\\..*", "javax\\..*", "scala\\..*"],
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Evolution Engineering
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build.sbt
+++ b/build.sbt
@@ -12,19 +12,21 @@ organizationHomepage := Some(url("https://evolution.com"))
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.13.8", "2.12.15")
+crossScalaVersions := Seq("3.8.4", "2.13.18")
 
 releaseCrossBuild := true
 
 Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings")
 
+scalacOptsFailOnWarn := Some(false) // Option -Xfatal-warnings is a deprecated alias
+
 publishTo := Some(Resolver.evolutionReleases)
 
 libraryDependencies ++= Seq(
-  "com.github.blemale"  %% "scaffeine"           % "5.1.2",
-  "com.evolutiongaming" %% "executor-tools"      % "1.0.2",
-  "io.prometheus"        % "simpleclient_common" % "0.6.0",
-  "org.scalatest"       %% "scalatest"           % "3.0.8" % Test
+  "com.github.blemale" %% "scaffeine" % "5.3.0",
+  "com.evolutiongaming" %% "executor-tools" % "1.0.5",
+  "io.prometheus" % "simpleclient_common" % "0.6.0",
+  "org.scalatest" %% "scalatest" % "3.2.20" % Test,
 )
 
 licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")))

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ releaseCrossBuild := true
 
 Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings")
 
-scalacOptsFailOnWarn := Some(false) // Option -Xfatal-warnings is a deprecated alias
+scalacOptions -= "-Xfatal-warnings"
+scalacOptions += "-Werror"
 
 publishTo := Some(Resolver.evolutionReleases)
 
@@ -29,7 +30,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.20" % Test,
 )
 
-licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")))
+licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
 //addCommandAlias("check", "all versionPolicyCheck Compile/doc")
 addCommandAlias("check", "show version")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.12.12

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,9 +1,11 @@
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.5.0")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")

--- a/src/main/scala/com/evolutiongaming/scaffeine/MetricsStatsCounter.scala
+++ b/src/main/scala/com/evolutiongaming/scaffeine/MetricsStatsCounter.scala
@@ -93,7 +93,7 @@ class MetricsStatsCounter(registry: CollectorRegistry, prefix: String) extends S
 
   def registerEstimatedSize(f: => Long): Unit = {
     val child = new Gauge.Child() {
-      override def get() = f.toDouble
+      override def get(): Double = f.toDouble
     }
     gauge.setChild(child)
   }

--- a/src/main/scala/com/evolutiongaming/scaffeine/MetricsStatsCounter.scala
+++ b/src/main/scala/com/evolutiongaming/scaffeine/MetricsStatsCounter.scala
@@ -8,7 +8,7 @@ class MetricsStatsCounter(registry: CollectorRegistry, prefix: String) extends S
 
   private def register(collector: Collector): Unit = {
     try {
-      registry register collector
+      registry.register(collector)
     } catch {
       case _: IllegalArgumentException => // unfortunately there is no way to check if a collector already registered
     }
@@ -68,7 +68,8 @@ class MetricsStatsCounter(registry: CollectorRegistry, prefix: String) extends S
     0,
     0,
     eviction.get.toLong,
-    0)
+    0,
+  )
 
   override def recordMisses(i: Int): Unit = misses.inc(i.toDouble)
 

--- a/src/main/scala/com/evolutiongaming/scaffeine/ScalaAsyncLoadingCache.scala
+++ b/src/main/scala/com/evolutiongaming/scaffeine/ScalaAsyncLoadingCache.scala
@@ -1,11 +1,10 @@
 package com.evolutiongaming.scaffeine
 
-import java.util.concurrent.ExecutionException
-
 import com.evolutiongaming.concurrent.{CurrentThreadExecutionContext, ExecutionContextExecutorServiceFactory}
 import com.github.benmanes.caffeine.cache.{AsyncLoadingCache => CaffeineAsyncLoadingCache}
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 
+import java.util.concurrent.ExecutionException
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future, blocking}
@@ -13,21 +12,22 @@ import scala.util.{Failure, Try}
 
 class ScalaAsyncLoadingCache[K, V](
   underlying: CaffeineAsyncLoadingCache[K, V],
-  statsCounter: Option[MetricsStatsCounter] = None) extends AsyncLoadingCache(underlying) {
+  statsCounter: Option[MetricsStatsCounter] = None,
+) extends AsyncLoadingCache(underlying) {
 
   def getFuture(key: K): Future[Option[V]] = {
-    val cf = underlying get key
+    val cf = underlying.get(key)
     if (cf.isDone) {
       Future fromTry Try(Option(cf.get())).recoverWith { case e: ExecutionException => Failure(e.getCause) }
     } else {
-      (cf.toScala map Option.apply) (CurrentThreadExecutionContext)
+      (cf.toScala map Option.apply)(using CurrentThreadExecutionContext)
     }
   }
 
   def getBlocking(key: K): Option[V] = getBlocking(key, Duration.Inf)
 
   def getBlocking(key: K, timeout: Duration): Option[V] = {
-    val cf = underlying get key
+    val cf = underlying.get(key)
 
     def get = Option {
       if (timeout.isFinite) cf.get(timeout.length, timeout.unit)
@@ -46,10 +46,14 @@ object ScalaAsyncLoadingCache {
   def apply[K, V](
     scaffeine: Scaffeine[Any, Any],
     loader: K => Future[Option[V]],
-    statsCounter: Option[MetricsStatsCounter])
-    (implicit ec: ExecutionContext): ScalaAsyncLoadingCache[K, V] = {
+    statsCounter: Option[MetricsStatsCounter],
+  )(implicit
+    ec: ExecutionContext,
+  ): ScalaAsyncLoadingCache[K, V] = {
 
-    val l = loader andThen { _.map { _ getOrElse null.asInstanceOf[V] }(CurrentThreadExecutionContext) }
+    // scalastyle:off null
+    val l = loader andThen { _.map { _ getOrElse null.asInstanceOf[V] }(using CurrentThreadExecutionContext) }
+    // scalastyle:on null
 
     val executorService = ExecutionContextExecutorServiceFactory(ec)
     val cache = scaffeine.executor(executorService).buildAsyncFuture[K, V](l).underlying

--- a/src/main/scala/com/evolutiongaming/scaffeine/package.scala
+++ b/src/main/scala/com/evolutiongaming/scaffeine/package.scala
@@ -9,21 +9,34 @@ package object scaffeine {
 
   implicit class ScaffeineOps(val scaffeine: Scaffeine[Any, Any]) extends AnyVal {
 
-    def asyncCache[K, V](loader: (K) => Future[Option[V]])
-      (implicit ec: ExecutionContext): ScalaAsyncLoadingCache[K, V] = {
+    def asyncCache[K, V](
+      loader: (K) => Future[Option[V]],
+    )(implicit
+      ec: ExecutionContext,
+    ): ScalaAsyncLoadingCache[K, V] = {
 
       ScalaAsyncLoadingCache(scaffeine, loader, None)
     }
 
-    def asyncCache[K, V](loader: (K) => Future[Option[V]], stats: (String, CollectorRegistry))
-      (implicit ec: ExecutionContext): ScalaAsyncLoadingCache[K, V] = {
+    def asyncCache[K, V](
+      loader: (K) => Future[Option[V]],
+      stats: (String, CollectorRegistry),
+    )(implicit
+      ec: ExecutionContext,
+    ): ScalaAsyncLoadingCache[K, V] = {
 
       val (name, registry) = stats
-      asyncCache(name, registry)(loader)(ec)
+      asyncCache(name, registry)(loader)(using ec)
     }
 
-    def asyncCache[K, V](name: String, registry: CollectorRegistry)(loader: (K) => Future[Option[V]])
-      (implicit ec: ExecutionContext): ScalaAsyncLoadingCache[K, V] = {
+    def asyncCache[K, V](
+      name: String,
+      registry: CollectorRegistry,
+    )(
+      loader: (K) => Future[Option[V]],
+    )(implicit
+      ec: ExecutionContext,
+    ): ScalaAsyncLoadingCache[K, V] = {
 
       val statsCounter = new MetricsStatsCounter(registry, name)
       ScalaAsyncLoadingCache(scaffeine.recordStats(() => statsCounter), loader, Some(statsCounter))

--- a/src/main/scala/com/evolutiongaming/scaffeine/package.scala
+++ b/src/main/scala/com/evolutiongaming/scaffeine/package.scala
@@ -10,7 +10,7 @@ package object scaffeine {
   implicit class ScaffeineOps(val scaffeine: Scaffeine[Any, Any]) extends AnyVal {
 
     def asyncCache[K, V](
-      loader: (K) => Future[Option[V]],
+      loader: K => Future[Option[V]],
     )(implicit
       ec: ExecutionContext,
     ): ScalaAsyncLoadingCache[K, V] = {
@@ -19,7 +19,7 @@ package object scaffeine {
     }
 
     def asyncCache[K, V](
-      loader: (K) => Future[Option[V]],
+      loader: K => Future[Option[V]],
       stats: (String, CollectorRegistry),
     )(implicit
       ec: ExecutionContext,
@@ -33,7 +33,7 @@ package object scaffeine {
       name: String,
       registry: CollectorRegistry,
     )(
-      loader: (K) => Future[Option[V]],
+      loader: K => Future[Option[V]],
     )(implicit
       ec: ExecutionContext,
     ): ScalaAsyncLoadingCache[K, V] = {

--- a/src/test/scala/com/evolutiongaming/scaffeine/test/ScaffeineSpec.scala
+++ b/src/test/scala/com/evolutiongaming/scaffeine/test/ScaffeineSpec.scala
@@ -1,10 +1,10 @@
 package com.evolutiongaming.scaffeine.test
 
-
 import com.evolutiongaming.concurrent.CurrentThreadExecutionContext
-import org.scalatest.{AsyncFlatSpec, Matchers}
 import com.evolutiongaming.scaffeine._
 import com.github.blemale.scaffeine.Scaffeine
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.{ExecutionContext, ExecutionException, Future}
 import scala.util.control.NoStackTrace
@@ -12,44 +12,46 @@ import scala.util.control.NoStackTrace
 class ScaffeineSpec extends AsyncFlatSpec with Matchers {
 
   it should "return existing cached value when called synchronously" in {
-    cache getBlocking 5 shouldEqual Some("5")
+    cache.getBlocking(5) shouldEqual Some("5")
   }
 
   it should "return existing cached value when called asynchronously" in {
-    cache get 4 map { _ shouldEqual "4" }
+    cache.get(4) map { _ shouldEqual "4" }
   }
 
   it should "return existing cached value when called asynchronously with Option support" in {
-    cache getFuture 3 map { _ shouldEqual Some("3") }
+    cache.getFuture(3) map { _ shouldEqual Some("3") }
   }
 
   it should "return existing cached value in future when called synchronously" in {
-    cache getBlocking 55 shouldEqual Some("55")
+    cache.getBlocking(55) shouldEqual Some("55")
   }
 
   it should "return existing cached value in future when called asynchronously" in {
-    cache get 54 map { _ shouldEqual "54" }
+    cache.get(54) map { _ shouldEqual "54" }
   }
 
   it should "return existing cached value in future when called asynchronously with Option support" in {
-    cache getFuture 53 map { _ shouldEqual Some("53") }
+    cache.getFuture(53) map { _ shouldEqual Some("53") }
   }
 
   it should "return None when called synchronously for non existent value" in {
-    cache getBlocking 104 shouldEqual None
+    cache.getBlocking(104) shouldEqual None
   }
 
   it should "return None when called asynchronously for non existent value" in {
-    cache getFuture 105 map { _ shouldEqual None }
+    cache.getFuture(105) map { _ shouldEqual None }
   }
 
   it should "return null when called asynchronously for non existent value without Option support" in {
-    cache get 106 map { _ shouldEqual null }
+    // scalastyle:off null
+    cache.get(106) map { _ shouldEqual null }
+    // scalastyle:on null
   }
 
   it should "return None when called synchronously for a key which fails to load a value" in {
     assertThrows[ExecutionException] {
-      cache getBlocking 204
+      cache.getBlocking(204)
     }
   }
 
@@ -64,7 +66,7 @@ class ScaffeineSpec extends AsyncFlatSpec with Matchers {
   it should "call loader only once per synchronous call for non existent value" in {
     implicit val ec = CurrentThreadExecutionContext
     var counter = 0
-    val cache = Scaffeine().asyncCache { k: Int => Future { counter += k; None } }
+    val cache = Scaffeine().asyncCache { (k: Int) => Future { counter += k; None } }
 
     (1 to 100).foreach(cache.getBlocking)
     counter shouldEqual (1 to 100).sum
@@ -73,12 +75,12 @@ class ScaffeineSpec extends AsyncFlatSpec with Matchers {
   object CacheException extends Exception with NoStackTrace
 
   implicit val ec: ExecutionContext = ExecutionContext.global
-  private def cache = Scaffeine().asyncCache { k: Int =>
+  private def cache = Scaffeine().asyncCache { (k: Int) =>
     k match {
-      case i if i < 50              => Future.successful(Some(s"$k"))
-      case i if i >= 50 && i < 100  => Future(Some(s"$k"))
+      case i if i < 50 => Future.successful(Some(s"$k"))
+      case i if i >= 50 && i < 100 => Future(Some(s"$k"))
       case i if i >= 100 && i < 200 => Future.successful(None)
-      case i if i >= 200            => Future.failed(CacheException)
+      case i if i >= 200 => Future.failed(CacheException)
     }
   }
 }


### PR DESCRIPTION
# Merge Request: Cross-compile to Scala 3

## Summary
Updated project build configuration to support Scala 3 cross-compilation.

## Changes

### Scala Versions
| Setting | Before | After |
|---------|--------|-------|
| Scala 3 | ❌ | ✅ 3.8.4 |
| Scala 2.13 | ✅ 2.13.8 | ✅ 2.13.18 |
| Scala 2.12 | ✅ 2.12.15 | ❌ |
| Default | 2.13.18 | 3.8.4 |

### Build Configuration
| Option | Before | After |
|--------|--------|-------|
| sbt.version | 1.6.2 | 1.12.12 |

### Dependencies
| Library | Before | After |
|---------|--------|-------|
| scaffeine | 5.1.2 | 5.3.0 |
| executor-tools | 1.0.2 | 1.0.5 |
| scalatest | 3.0.8 (Test) | 3.2.20 (Test) |

### SBT Plugins
| Plugin | Before | After |
|--------|--------|-------|
| sbt-scoverage | 1.9.3 | 2.4.4 |
| sbt-coveralls | 1.3.1 | 1.3.15 |
| sbt-release | 1.1.0 | 1.5.0 |
| sbt-scalafmt | - | 2.6.1 |

## Supported Scala Versions
- ✅ Scala 3.8.4
- ✅ Scala 2.13.18
